### PR TITLE
Retrofit connection timeout fixed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.android.support:design:28.0.0'
 
+    //OkHttp
+    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+
     //Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.1.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.1.0'

--- a/app/src/main/java/hr/foi/air/sportloc/service/caller/WebServiceCaller.java
+++ b/app/src/main/java/hr/foi/air/sportloc/service/caller/WebServiceCaller.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.MutableLiveData;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import hr.foi.air.sportloc.service.model.CommentModel;
 import hr.foi.air.sportloc.service.model.EventFilterModel;
@@ -18,6 +19,7 @@ import hr.foi.air.sportloc.service.rest.ApiInterface;
 import hr.foi.air.sportloc.service.serviceUtil.BooleanCallback;
 import hr.foi.air.sportloc.service.serviceUtil.DataUtil;
 import hr.foi.air.sportloc.service.serviceUtil.MessageCallback;
+import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -30,10 +32,17 @@ public class WebServiceCaller {
     private static final String BASE_URL = "https://sportloc-backend-test.herokuapp.com/";
 
     private WebServiceCaller() {
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                .readTimeout(60, TimeUnit.SECONDS)
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .build();
+
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(BASE_URL)
                 .addConverterFactory(GsonConverterFactory.create())
+                .client(okHttpClient)
                 .build();
+
         api = retrofit.create(ApiInterface.class);
     }
 


### PR DESCRIPTION
Fixed the timeout issue while trying to wake up the web server and establish the connection for the first time using Retrofit by adding Square's OkHttp client library to the project and setting the timeout values for the client inside the WebServiceCaller class.